### PR TITLE
Add support for Launchpad.net

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,6 +7,8 @@ Go-OAuth is a [Go](http://golang.org/) client for the OAuth 1.0, OAuth 1.0a and
 [RFC 5849](https://tools.ietf.org/html/rfc5849) Protocols. The package supports
 HMAC-SHA1, RSA-SHA1 and PLAINTEXT signatures.
 
+This
+
 ## Installation
 
     go get github.com/garyburd/go-oauth/oauth

--- a/oauth/examples_test.go
+++ b/oauth/examples_test.go
@@ -15,7 +15,7 @@
 package oauth_test
 
 import (
-	"github.com/garyburd/go-oauth/oauth"
+	"github.com/bergotorino/go-oauth/oauth"
 	"net/http"
 	"net/url"
 	"strings"


### PR DESCRIPTION
This commit adds OAuth necessary bits for being able to talk to
Launchpad and hear back from it.

Apart from this changes every Launchpad client should specify extra
headers. These are:
 - "accept" = "application/json"
 - "accept-encoding" = "gzip, deflate"